### PR TITLE
feat: 찜 도서와 별점(리뷰) 도서 분리 반영한 추천 알고리즘 고도화

### DIFF
--- a/recommend-server/main.py
+++ b/recommend-server/main.py
@@ -28,9 +28,14 @@ class BookInfoDTO(BaseModel):
     id: int
     genre :str
 
+class RatedBookDTO(BaseModel):
+    id: int
+    rating: float
+
 class RecommendRequestDTO(BaseModel):
     preferredGenres: List[str]  # 유저의 선호 장르 리스트
-    favoriteBookIds: List[int]  # 유저의 찜 목록 리스트
+    favoriteBooks: List[int]  # 유저의 찜 목록 리스트
+    ratedBooks: List[RatedBookDTO] # 유저의 별점 목록 리스트
     bookInfos: List[BookInfoDTO]
 
 # 응답 DTO
@@ -41,24 +46,32 @@ class RecommendResultDTO(BaseModel):
 def genre_to_vector(genre: str) -> List[int]:
     return [1 if genre.upper() == g else 0 for g in ALL_GENRES]
 
-# 사용자 벡터 생성 : 선호 장르 + 찜 도서 장르 평균
-def build_user_vector(preferredGenres: List[str], favoriteBookIds: List[int], bookInfos: List[BookInfoDTO]) -> np.ndarray:
-    genre_vectors = [genre_to_vector(g) for g in preferredGenres]
+# 사용자 벡터 생성 : 선호 장르 + 찜 도서 장르 , 별점 4.0 이상 가중치 평균
+def build_user_vector(preferredGenres, favoriteBooks, ratedBooks, bookInfos ) -> np.ndarray:
 
-    # 찜한 도서들 장르 찾기
-    favorite_genres = []
+    genre_vectors:List[np.ndarray] = [np.array(genre_to_vector(g)) for g in preferredGenres]  # 장르 벡터 변환
+
+    # 찜한 도서들 장르 + 별점 기반 가중치 반영
     book_map = {b.id:b.genre for b in bookInfos}
-    for book_id in favoriteBookIds:
+
+    # 찜한 도서 (기본 가중치 1.2)
+    for book_id in favoriteBooks:
         genre = book_map.get(book_id)
         if genre:
-            favorite_genres.append(genre)
+            vec = np.array(genre_to_vector(genre))
+            genre_vectors.append(vec * 1.2)
 
-    favorite_vectors = [genre_to_vector(g) for g in favorite_genres]
+    # 별점 기반 가중치
+    for rated in ratedBooks:
+        genre = book_map.get(rated.id)
+        if genre:
+            vec = np.array(genre_to_vector(genre))
+            weight = get_rating_weight(rated.rating)
+            genre_vectors.append(vec * weight)
 
-    all_vectors = genre_vectors + favorite_vectors
-    if not all_vectors:
+    if not genre_vectors:
         return np.zeros((1,len(ALL_GENRES)))
-    return np.mean(all_vectors,axis=0).reshape(1,-1)
+    return np.mean(genre_vectors,axis=0).reshape(1,-1)
 
 # 모든 도서 벡터화
 def build_book_vectors(bookInfos: List[BookInfoDTO]) -> Dict[int, np.ndarray]:
@@ -67,24 +80,39 @@ def build_book_vectors(bookInfos: List[BookInfoDTO]) -> Dict[int, np.ndarray]:
         vectors[book.id] = np.array(genre_to_vector(book.genre)).reshape(1,-1)
     return vectors
 
+# 가중치 계산 함수
+def get_rating_weight(rating: float) -> float:
+    if rating >= 5.0:
+        return 2.0
+    elif rating >= 4.0:
+        return 1.8
+    elif rating >= 3.0:
+        return 1.5
+    elif rating >= 2.0:
+        return 1.2
+    else:
+        return 1.0
 
 @app.post("/recommend",response_model=RecommendResultDTO)
 def recommend(request: RecommendRequestDTO):
     print("✅ FastAPI 요청 들어옴!")
     print(f"받은 장르 목록: {request.preferredGenres}")
-    print(f"찜 도서: {request.favoriteBookIds}")
+    print(f"찜 도서: {request.favoriteBooks}")
     print(f"전체 도서 수: {len(request.bookInfos)}")
 
-    user_vector = build_user_vector(request.preferredGenres,request.favoriteBookIds,request.bookInfos)
+    user_vector = build_user_vector(request.preferredGenres,request.favoriteBooks,request.ratedBooks,request.bookInfos)
     book_vectors = build_book_vectors(request.bookInfos)
 
     scores = []
     for book_id, vector in book_vectors.items():
         sim = cosine_similarity(user_vector,vector)[0][0]
+        print(f"Book ID: {book_id}, 유사도: {sim:.4f}")
         scores.append((book_id,sim))
 
     # 유사도 기준 정렬 후 상위 10개 추천
     scores.sort(key=lambda x: x[1], reverse=True)
     top_books = [book_id for book_id,_ in scores[:10]]
+
+    print("최종 추천 도서:", top_books)
 
     return RecommendResultDTO(bookIds=top_books)

--- a/src/main/java/com/github/bookproject/book/dto/BookResponseDTO.java
+++ b/src/main/java/com/github/bookproject/book/dto/BookResponseDTO.java
@@ -18,7 +18,7 @@ public class BookResponseDTO {
     private String author;
     private String imageUrl;
     private GenreType genre;
-    private Double rating;
+    private double rating;
     private BookStatus status;
 
     public static BookResponseDTO from(Book book) {

--- a/src/main/java/com/github/bookproject/recommend/dto/RecommendRequestDTO.java
+++ b/src/main/java/com/github/bookproject/recommend/dto/RecommendRequestDTO.java
@@ -12,7 +12,8 @@ import java.util.List;
 @AllArgsConstructor
 public class RecommendRequestDTO {
     private List<String> preferredGenres;
-    private List<Long> favoriteBookIds;
+    private List<Integer> favoriteBooks;
+    private List<RatedBookDTO> ratedBooks;
     private List<BookInfoDTO> bookInfos;
 
     @Getter
@@ -22,6 +23,15 @@ public class RecommendRequestDTO {
     public static class BookInfoDTO {
         private Long id;
         private String genre;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RatedBookDTO {
+        private Long id;
+        private double rating;
     }
 
 }

--- a/src/main/java/com/github/bookproject/review/repository/ReviewRepository.java
+++ b/src/main/java/com/github/bookproject/review/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import com.github.bookproject.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -12,4 +13,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByBookId(Long bookId);
 
     boolean existsByUserIdAndBookId(Long userId, Long bookId);
+
+    List<Review> findByUserId(Long userId);
 }


### PR DESCRIPTION
- FastApi 서버에 사용자의 찜 목록과 별점(리뷰) 목록을 분리하여 가중치 반영 
  * (찜 도서: 기본 1.2 가중치 / 별점 도서 : 별점에 따라 1.0 ~ 2.0 사이 가중치 차등 적용)
- RecommendRequestDTO , RecommendService 로직 수정
- 장르 벡터 가중 평균 방식 개선