### PR TITLE
feat: 독서 기록 기능 구현 및 완료 처리 로직 추가

### DIFF
--- a/src/main/java/com/github/bookproject/book/controller/BookController.java
+++ b/src/main/java/com/github/bookproject/book/controller/BookController.java
@@ -4,6 +4,7 @@ import com.github.bookproject.auth.entity.GenreType;
 import com.github.bookproject.book.dto.BookDetailsResponseDTO;
 import com.github.bookproject.book.dto.BookResponseDTO;
 import com.github.bookproject.book.service.BookService;
+import com.github.bookproject.global.config.auth.custom.CustomUserDetails;
 import com.github.bookproject.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -31,8 +33,11 @@ public class BookController {
 
     @Operation(summary = "도서 상세 조회")
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<BookDetailsResponseDTO>> getBookDetails(@PathVariable Long id) {
-        return ResponseEntity.ok(ApiResponse.success(bookService.getBookDetail(id)));
+    public ResponseEntity<ApiResponse<BookDetailsResponseDTO>> getBookDetails(@PathVariable Long id,
+                                                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        BookDetailsResponseDTO dto = bookService.getBookDetail(id,userId);
+        return ResponseEntity.ok(ApiResponse.success(dto));
     }
 
     @Operation(summary = "도서 검색")

--- a/src/main/java/com/github/bookproject/book/dto/BookDetailsResponseDTO.java
+++ b/src/main/java/com/github/bookproject/book/dto/BookDetailsResponseDTO.java
@@ -34,8 +34,9 @@ public class BookDetailsResponseDTO {
     private double rating;
     private BookStatus status;
     private List<ReviewResponseDTO> reviews;
+    private boolean isReading;
 
-    public static BookDetailsResponseDTO from(Book book,List<ReviewResponseDTO> reviews) {
+    public static BookDetailsResponseDTO from(Book book,List<ReviewResponseDTO> reviews,boolean isReading) {
         return BookDetailsResponseDTO.builder()
                 .id(book.getId())
                 .title(book.getTitle())
@@ -50,6 +51,7 @@ public class BookDetailsResponseDTO {
                 .rating(book.getRating())
                 .status(book.getStatus())
                 .reviews(reviews)
+                .isReading(isReading)
                 .build();
     }
 }

--- a/src/main/java/com/github/bookproject/book/service/BookService.java
+++ b/src/main/java/com/github/bookproject/book/service/BookService.java
@@ -6,6 +6,9 @@ import com.github.bookproject.book.entity.Book;
 import com.github.bookproject.book.repository.BookRepository;
 import com.github.bookproject.global.exception.AppException;
 import com.github.bookproject.global.exception.ErrorCode;
+import com.github.bookproject.readingRecord.dto.ReadingRecordResponseDTO;
+import com.github.bookproject.readingRecord.entity.ReadingRecord;
+import com.github.bookproject.readingRecord.repository.ReadingRecordRepository;
 import com.github.bookproject.review.dto.ReviewResponseDTO;
 import com.github.bookproject.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,22 +24,27 @@ import java.util.stream.Collectors;
 public class BookService {
     private final BookRepository bookRepository;
     private final ReviewRepository reviewRepository;
+    private final ReadingRecordRepository readingRecordRepository;
 
     public Page<BookResponseDTO> getAllBooks(Pageable pageable) {
         return bookRepository.findAll(pageable)
                 .map(BookResponseDTO::from);
     }
 
-    public BookDetailsResponseDTO getBookDetail(Long id) {
-        Book book = bookRepository.findById(id)
+    public BookDetailsResponseDTO getBookDetail(Long bookId,Long userId) {
+        Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new AppException(ErrorCode.BOOK_NOT_FOUND));
 
-        List<ReviewResponseDTO> reviews = reviewRepository.findByBookId(id)
+        // 리뷰 목록 조회
+        List<ReviewResponseDTO> reviews = reviewRepository.findByBookId(bookId)
                 .stream()
                 .map(ReviewResponseDTO::from)
                 .collect(Collectors.toList());
 
-        return BookDetailsResponseDTO.from(book,reviews);
+        // 유저가 책의 독서 기록을 가지는지 여부 확인
+        boolean isReading = readingRecordRepository.findByUserIdAndBookId(userId,bookId).isPresent();
+
+        return BookDetailsResponseDTO.from(book,reviews,isReading);
     }
 
     public void registerBook(BookRequestDTO dto) {

--- a/src/main/java/com/github/bookproject/global/exception/ErrorCode.java
+++ b/src/main/java/com/github/bookproject/global/exception/ErrorCode.java
@@ -24,7 +24,15 @@ public enum ErrorCode {
     REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN,"리뷰를 삭제할 권한이 없습니다."),
     DUPLICATE_REVIEW(HttpStatus.CONFLICT,"리뷰를 작성한 도서입니다."),
     INVALID_RATING(HttpStatus.FORBIDDEN,"별점은 1.0 ~ 5.0 사이여야 합니다."),
-    REVIEW_CONFLICT(HttpStatus.CONFLICT,"다른 사용자에 요청으로 인해 별점 업데이트에 실패하였습니다. 다시 시도해 주세요.");
+    REVIEW_CONFLICT(HttpStatus.CONFLICT,"다른 사용자에 요청으로 인해 별점 업데이트에 실패하였습니다. 다시 시도해 주세요."),
+
+    // record
+    DUPLICATE_READING_RECORD(HttpStatus.CONFLICT,"이미 독서 기록중인 도서입니다."),
+    READING_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 기록을 찾을 수 없습니다."),
+    READING_RECORD_FORBIDDEN(HttpStatus.FORBIDDEN,"사용자가 일치하지 않습니다."),
+    INVALID_PROGRESS(HttpStatus.FORBIDDEN,"진행률은 0.0 ~ 1.0 사이여야 합니다."),
+    ALREADY_COMPLETE(HttpStatus.ALREADY_REPORTED,"이미 독서 완료한 기록입니다."),
+    INVALID_INITIAL_READING_STATUS(HttpStatus.FORBIDDEN,"독서 기록 생성 시 상태는 COMPLETE 일 수 없습니다.");
 
 
 

--- a/src/main/java/com/github/bookproject/readingRecord/controller/ReadingRecordController.java
+++ b/src/main/java/com/github/bookproject/readingRecord/controller/ReadingRecordController.java
@@ -1,0 +1,68 @@
+package com.github.bookproject.readingRecord.controller;
+
+import com.github.bookproject.global.config.auth.custom.CustomUserDetails;
+import com.github.bookproject.global.dto.ApiResponse;
+import com.github.bookproject.readingRecord.dto.ProgressUpdateRequestDTO;
+import com.github.bookproject.readingRecord.dto.ReadingRecordRequestDTO;
+import com.github.bookproject.readingRecord.dto.ReadingRecordUpdateRequestDTO;
+import com.github.bookproject.readingRecord.service.ReadingRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/records")
+public class ReadingRecordController {
+
+    private final ReadingRecordService readingRecordService;
+
+    // 독서 기록
+    @Operation(summary = "독서 기록 진행")
+    @PostMapping
+    public ResponseEntity<ApiResponse<String>> createRecord(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                            @RequestBody ReadingRecordRequestDTO dto) {
+        readingRecordService.creatRecord(userDetails.getUser().getId(),dto);
+        return ResponseEntity.ok(ApiResponse.success("✅독서 기록이 생성되었습니다."));
+    }
+
+    // 독서 기록 수정
+    @Operation(summary = "독서 기록 내용 수정")
+    @PatchMapping("/{recordId}")
+    public ResponseEntity<ApiResponse<String>> updateRecord(@PathVariable Long recordId,
+                                                            @RequestBody ReadingRecordUpdateRequestDTO dto,
+                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        readingRecordService.updateRecord(userDetails.getUser().getId(),dto,recordId);
+        return ResponseEntity.ok(ApiResponse.success("✅독서 기록 내용이 수정되었습니다."));
+    }
+
+    @Operation(summary = "독서 진행률 수정")
+    @PatchMapping("/{recordId}/progress")
+    public ResponseEntity<ApiResponse<String>> updateRecordProgress(@PathVariable Long recordId,
+                                                                    @RequestBody ProgressUpdateRequestDTO dto,
+                                                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+        readingRecordService.updateProgress(recordId,dto.getProgress(),userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("✅독서 진행률 수정되었습니다."));
+    }
+
+    @Operation(summary = "독서 완료 처리")
+    @PatchMapping("/{recordId}/complete")
+    public ResponseEntity<ApiResponse<String>> completeReading(@PathVariable Long recordId,
+                                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        readingRecordService.completeReading(userDetails.getUser().getId(),recordId);
+        return ResponseEntity.ok(ApiResponse.success("✅독서가 완료되었습니다."));
+    }
+
+    // 독서 기록 삭제
+    @Operation(summary = "독서 기록 삭제")
+    @DeleteMapping("/{recordId}")
+    public ResponseEntity<ApiResponse<String>> deleteRecord(@PathVariable Long recordId,
+                                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        readingRecordService.deleteRecord(recordId,userDetails.getUser().getId());
+        return ResponseEntity.ok(ApiResponse.success("✅독서 기록이 삭제되었습니다."));
+    }
+
+
+}

--- a/src/main/java/com/github/bookproject/readingRecord/dto/ProgressUpdateRequestDTO.java
+++ b/src/main/java/com/github/bookproject/readingRecord/dto/ProgressUpdateRequestDTO.java
@@ -1,0 +1,19 @@
+package com.github.bookproject.readingRecord.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProgressUpdateRequestDTO {
+
+    @DecimalMin("0.0")
+    @DecimalMax("1.0")
+    private float progress;
+}

--- a/src/main/java/com/github/bookproject/readingRecord/dto/ReadingRecordRequestDTO.java
+++ b/src/main/java/com/github/bookproject/readingRecord/dto/ReadingRecordRequestDTO.java
@@ -1,0 +1,26 @@
+package com.github.bookproject.readingRecord.dto;
+
+import com.github.bookproject.readingRecord.entity.ReadingStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadingRecordRequestDTO {
+
+    @NotNull(message = "도서 ID 는 필수입니다.")
+    private Long bookId;
+
+    private String memo;
+
+    @NotNull(message = "독서 상태는 필수입니다.")
+    private ReadingStatus status;
+
+}

--- a/src/main/java/com/github/bookproject/readingRecord/dto/ReadingRecordResponseDTO.java
+++ b/src/main/java/com/github/bookproject/readingRecord/dto/ReadingRecordResponseDTO.java
@@ -1,0 +1,34 @@
+package com.github.bookproject.readingRecord.dto;
+
+import com.github.bookproject.readingRecord.entity.ReadingRecord;
+import com.github.bookproject.readingRecord.entity.ReadingStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadingRecordResponseDTO {
+    private Long recordId;
+    private String memo;
+    private ReadingStatus status;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Float progress;
+
+    public static ReadingRecordResponseDTO from(ReadingRecord record) {
+        return ReadingRecordResponseDTO.builder()
+                .recordId(record.getId())
+                .memo(record.getMemo())
+                .status(record.getStatus())
+                .startDate(record.getStartDate())
+                .endDate(record.getEndDate())
+                .progress(record.getProgress())
+                .build();
+    }
+}

--- a/src/main/java/com/github/bookproject/readingRecord/dto/ReadingRecordUpdateRequestDTO.java
+++ b/src/main/java/com/github/bookproject/readingRecord/dto/ReadingRecordUpdateRequestDTO.java
@@ -1,0 +1,21 @@
+package com.github.bookproject.readingRecord.dto;
+
+import com.github.bookproject.readingRecord.entity.ReadingStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadingRecordUpdateRequestDTO {
+
+    private String memo;
+
+    @NotNull(message = "독서 상태는 필수입니다.")
+    private ReadingStatus status;
+
+}

--- a/src/main/java/com/github/bookproject/readingRecord/entity/ReadingRecord.java
+++ b/src/main/java/com/github/bookproject/readingRecord/entity/ReadingRecord.java
@@ -2,6 +2,7 @@ package com.github.bookproject.readingRecord.entity;
 
 import com.github.bookproject.auth.entity.User;
 import com.github.bookproject.book.entity.Book;
+import com.github.bookproject.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.time.LocalDate;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReadingRecord {
+public class ReadingRecord extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -23,6 +24,9 @@ public class ReadingRecord {
     @ManyToOne(fetch = FetchType.LAZY)
     private Book book;
 
+    @Column(length = 10000)
+    private String memo;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ReadingStatus status;
@@ -32,15 +36,38 @@ public class ReadingRecord {
 
     private Float progress;    // 0.0 ~ 1.0 진행률
 
-    public static ReadingRecord create(User user, Book book, ReadingStatus status, LocalDate startDate, LocalDate endDate, Float progress) {
+    public static ReadingRecord create(User user, Book book, String memo, ReadingStatus status, LocalDate startDate, LocalDate endDate, Float progress) {
         ReadingRecord readingRecord = new ReadingRecord();
         readingRecord.user = user;
         readingRecord.book = book;
+        readingRecord.memo = memo;
         readingRecord.status = status;
         readingRecord.startDate = startDate;
         readingRecord.endDate = endDate;
         readingRecord.progress = progress;
         return readingRecord;
+    }
+
+    public void update(String memo, ReadingStatus status) {
+        this.memo = memo;
+        this.status = status;
+        if (status == ReadingStatus.COMPLETED) {
+            this.endDate = LocalDate.now();
+        }
+    }
+
+    public void updateProgress(Float progress) {
+        this.progress = progress;
+        if (progress >= 1.0f) {
+            this.status = ReadingStatus.COMPLETED;
+            this.endDate = LocalDate.now();
+        }
+    }
+
+    public void completeReading() {
+        this.progress = 1.0f;
+        this.status = ReadingStatus.COMPLETED;
+        this.endDate = LocalDate.now();
     }
 
 

--- a/src/main/java/com/github/bookproject/readingRecord/entity/ReadingStatus.java
+++ b/src/main/java/com/github/bookproject/readingRecord/entity/ReadingStatus.java
@@ -1,7 +1,7 @@
 package com.github.bookproject.readingRecord.entity;
 
 public enum ReadingStatus {
-    WISHLIST,   // 읽고 싶은 책
+    NOT_STARTED,   // 시작 전
     READING,    // 읽는 중
-    COMPLETED   // 읽음
+    COMPLETED   // 독서 완료
 }

--- a/src/main/java/com/github/bookproject/readingRecord/repository/ReadingRecordRepository.java
+++ b/src/main/java/com/github/bookproject/readingRecord/repository/ReadingRecordRepository.java
@@ -1,0 +1,13 @@
+package com.github.bookproject.readingRecord.repository;
+
+import com.github.bookproject.readingRecord.entity.ReadingRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReadingRecordRepository extends JpaRepository<ReadingRecord, Long> {
+
+    Optional<ReadingRecord> findByUserIdAndBookId(Long userId, Long id);
+}

--- a/src/main/java/com/github/bookproject/readingRecord/service/ReadingRecordService.java
+++ b/src/main/java/com/github/bookproject/readingRecord/service/ReadingRecordService.java
@@ -1,0 +1,111 @@
+package com.github.bookproject.readingRecord.service;
+
+import com.github.bookproject.auth.entity.User;
+import com.github.bookproject.auth.repository.UserRepository;
+import com.github.bookproject.book.entity.Book;
+import com.github.bookproject.book.repository.BookRepository;
+import com.github.bookproject.global.exception.AppException;
+import com.github.bookproject.global.exception.ErrorCode;
+import com.github.bookproject.readingRecord.dto.ReadingRecordRequestDTO;
+import com.github.bookproject.readingRecord.dto.ReadingRecordUpdateRequestDTO;
+import com.github.bookproject.readingRecord.entity.ReadingRecord;
+import com.github.bookproject.readingRecord.entity.ReadingStatus;
+import com.github.bookproject.readingRecord.repository.ReadingRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ReadingRecordService {
+
+    private final ReadingRecordRepository readingRecordRepository;
+    private final UserRepository userRepository;
+    private final BookRepository bookRepository;
+
+    public void creatRecord(Long userId, ReadingRecordRequestDTO dto) {
+        // 독서 기록 셍성시 COMPLETE 값이 들어오는거 방지
+        if (dto.getStatus() == ReadingStatus.COMPLETED) {
+            throw new AppException(ErrorCode.INVALID_INITIAL_READING_STATUS);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
+
+        Book book = bookRepository.findById(dto.getBookId())
+                .orElseThrow(() -> new AppException(ErrorCode.BOOK_NOT_FOUND));
+
+        // 기록 중복 방지
+        if (readingRecordRepository.findByUserIdAndBookId(userId,book.getId()).isPresent()) {
+            throw new AppException(ErrorCode.DUPLICATE_READING_RECORD);
+        }
+
+        ReadingRecord record = ReadingRecord.create(
+                user,
+                book,
+                dto.getMemo(),
+                dto.getStatus(),
+                LocalDate.now(),
+                null,
+                0.0f   // 진행도 0.0으로 초기화
+        );
+        readingRecordRepository.save(record);
+    }
+
+    public void updateRecord(Long userId, ReadingRecordUpdateRequestDTO dto, Long recordId) {
+        ReadingRecord record = readingRecordRepository.findById(recordId)
+                .orElseThrow(() -> new AppException(ErrorCode.READING_RECORD_NOT_FOUND));
+
+        if (!record.getUser().getId().equals(userId)) {
+            throw new AppException(ErrorCode.READING_RECORD_FORBIDDEN);
+        }
+
+        record.update(dto.getMemo(), dto.getStatus());  // 만약, 상태를 독서 완료라고 변경한다면 endDate 현재 날짜로 자동 설정
+        readingRecordRepository.save(record);
+    }
+
+    public void updateProgress(Long recordId, float progress,Long userId) {
+        ReadingRecord record = readingRecordRepository.findById(recordId)
+                .orElseThrow(() -> new AppException(ErrorCode.READING_RECORD_NOT_FOUND));
+
+        if (!record.getUser().getId().equals(userId)) {
+            throw new AppException(ErrorCode.READING_RECORD_FORBIDDEN);
+        }
+
+        if (progress < 0.0f || progress > 1.0f) {
+            throw new AppException(ErrorCode.INVALID_PROGRESS);
+        }
+        record.updateProgress(progress);    // 만약, 진행도가 1.0 이 된다면 상태를 COMPLETE 로 변경하고, endDate 자동 설정
+        readingRecordRepository.save(record);
+    }
+
+    public void completeReading(Long userId, Long recordId) {
+        ReadingRecord record = readingRecordRepository.findById(recordId)
+                .orElseThrow(() -> new AppException(ErrorCode.READING_RECORD_NOT_FOUND));
+
+        if (!record.getUser().getId().equals(userId)) {
+            throw new AppException(ErrorCode.READING_RECORD_FORBIDDEN);
+        }
+        // 독서 완료 시점 중복 처리 방지
+        if (record.getStatus() == ReadingStatus.COMPLETED) {
+            throw new AppException(ErrorCode.ALREADY_COMPLETE);
+        }
+
+        record.completeReading();   // 독서 완료 버튼을 누르면 진행도 1.0 , 상태 COMPLETE , endDate 현재시간으로 변경
+        readingRecordRepository.save(record);
+    }
+
+    public void deleteRecord(Long recordId,Long userId) {
+        ReadingRecord record = readingRecordRepository.findById(recordId)
+                .orElseThrow(() -> new AppException(ErrorCode.READING_RECORD_NOT_FOUND));
+
+        if (!record.getUser().getId().equals(userId)) {
+            throw new AppException(ErrorCode.READING_RECORD_FORBIDDEN);
+        }
+
+        readingRecordRepository.deleteById(recordId);
+    }
+
+
+}


### PR DESCRIPTION
- 독서 기록 생성, 수정, 삭제, 완료 처리 API 구현
 (내용수정, 진행률 수정 부분 분리해서 api 구현)
- 진행률 수정 시 1.0이면 자동으로 완료 처리되도록 로직 추가
- 독서 기록 생성 시 '완료' 상태 방지 로직 추가
- 독서 기록 완료 시 중복 처리 방지 로직 추가