### PR TITLE
feat: 리뷰 기반 추천에 별점 4.0 이상 + 최근 리뷰일 가중치 반영

### DIFF
--- a/src/main/java/com/github/bookproject/book/dto/BookResponseDTO.java
+++ b/src/main/java/com/github/bookproject/book/dto/BookResponseDTO.java
@@ -8,6 +8,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -32,5 +35,12 @@ public class BookResponseDTO {
                 .status(book.getStatus())
                 .build();
     }
+
+    public double getRating() {
+        return BigDecimal.valueOf(rating)
+                .setScale(1, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+
 
 }

--- a/src/main/java/com/github/bookproject/recommend/dto/ReviewForKeywordDTO.java
+++ b/src/main/java/com/github/bookproject/recommend/dto/ReviewForKeywordDTO.java
@@ -1,8 +1,11 @@
 package com.github.bookproject.recommend.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
@@ -11,4 +14,7 @@ public class ReviewForKeywordDTO {
     private Long reviewId;
     private Long bookId;
     private String content;
+    private float rating;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/github/bookproject/recommend/service/RecommendService.java
+++ b/src/main/java/com/github/bookproject/recommend/service/RecommendService.java
@@ -112,7 +112,9 @@ public class RecommendService {
                 .map(review -> new ReviewForKeywordDTO(
                         review.getId(),
                         review.getBook().getId(),
-                        review.getContent()
+                        review.getContent(),
+                        review.getRating(),
+                        review.getCreatedAt()
                 ))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
- 별점 4.0 미만 리뷰는 추천 키워드 추출 제외
- 감정 분석 대체 방식으로 별점 리뷰 키워드 고도화
- 리뷰 작성일이 최근일수록 더 높은 가중치 부여 (1.5 ~ 0.7)
- 추천도서 응답 DTO에 별점 소수점 한 자리 반올림 적용 (마이페이지 리뷰 응답과 통일화)